### PR TITLE
Fix IndexError on single page watchlists

### DIFF
--- a/letterboxd_rss/__init__.py
+++ b/letterboxd_rss/__init__.py
@@ -45,11 +45,12 @@ def process(args):
         total_movies = int(total_movies)
         print(f"Found a total of {total_movies} movies")
 
-    last_page = soup.find_all("li", attrs={"class": "paginate-page"})[-1].text
-    last_page = int(last_page)
+    paginator = soup.find_all("li", attrs={"class": "paginate-page"})
+    page_count = int(paginator[-1].text) if paginator else 1
+    last_page_index = page_count + 1
 
     movies_added = 0
-    for page in range(1, last_page):
+    for page in range(1, last_page_index):
         if page > 1:
             r = s.get(watchlist_url + "/page/%i/" % page)
             soup = BeautifulSoup(r.text, "html.parser")


### PR DESCRIPTION
Thanks for this project! It's very clean + does its job well, small patch here.

The error is easily reproduceable with a single page watchlist:
```python
Found a total of 1 movies
Traceback (most recent call last):
  File "/home/j/.pyenv/versions/letterboxd-rss/bin/letterboxd-rss", line 5, in <module>
    from letterboxd_rss.__main__ import main
  File "/home/j/.pyenv/versions/letterboxd-rss/lib/python3.10/site-packages/letterboxd_rss/__main__.py", line 32, in <module>
    main(sys.argv[1:])
  File "/home/j/.pyenv/versions/letterboxd-rss/lib/python3.10/site-packages/letterboxd_rss/__main__.py", line 29, in main
    process(args)
  File "/home/j/.pyenv/versions/letterboxd-rss/lib/python3.10/site-packages/letterboxd_rss/__init__.py", line 48, in process
    last_page = soup.find_all("li", attrs={"class": "paginate-page"})[-1].text
IndexError: list index out of range
```